### PR TITLE
fix(deploy): Github Action 내 캐싱 관련 추가, 반응형 관련 유니온 타입 제거

### DIFF
--- a/.github/workflows/frontend-deploy-work.yml
+++ b/.github/workflows/frontend-deploy-work.yml
@@ -22,7 +22,7 @@ jobs:
         run: yarn install
         working-directory: ${{ env.working-directory }}
 
-      - name: Run build
+      - name: Build
         run: yarn build
         working-directory: ${{ env.working-directory }}
 
@@ -36,3 +36,6 @@ jobs:
       - name: Upload to S3
         run: aws s3 cp --recursive --region ap-northeast-2 dist s3://moment.r
         working-directory: ${{ env.working-directory }}
+
+      - name: Invalidate CloudFront Distribution
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_DISTRIBUTION_ID }} --paths "/*"

--- a/frontend/src/components/layout/Header/index.tsx
+++ b/frontend/src/components/layout/Header/index.tsx
@@ -1,5 +1,5 @@
+import { MEDIA_QUERY } from '../../../constants/styles';
 import { styled } from 'styled-components';
-import MEDIA_QUERY from '../../../constants/mediaQuery';
 
 const Header = () => {
   return (

--- a/frontend/src/constants/mediaQuery.ts
+++ b/frontend/src/constants/mediaQuery.ts
@@ -1,4 +1,4 @@
-import SCREEN_BREAKPOINT, { ScreenBreakpoint } from './screenBreakpoints';
+import { SCREEN_BREAKPOINT } from './screenBreakpoints';
 
 /**
  * css에서 반응형 디자인을 할 때 사용합니다.
@@ -20,7 +20,7 @@ import SCREEN_BREAKPOINT, { ScreenBreakpoint } from './screenBreakpoints';
  *   }
  * `
  */
-const MEDIA_QUERY: Readonly<Record<ScreenBreakpoint, string>> = {
+const MEDIA_QUERY: Readonly<Record<keyof typeof SCREEN_BREAKPOINT, string>> = {
   sm: `@media screen and (max-width: ${SCREEN_BREAKPOINT.sm}px)`,
   md: `@media screen and (max-width: ${SCREEN_BREAKPOINT.md}px)`,
   lg: `@media screen and (min-width: ${SCREEN_BREAKPOINT.lg}px)`,

--- a/frontend/src/constants/screenBreakpoints.ts
+++ b/frontend/src/constants/screenBreakpoints.ts
@@ -1,9 +1,5 @@
-export type ScreenBreakpoint = 'sm' | 'md' | 'lg';
-
-const SCREEN_BREAKPOINT = {
+export const SCREEN_BREAKPOINT = {
   sm: 375,
   md: 1023,
   lg: 1024,
 } as const;
-
-export default SCREEN_BREAKPOINT;

--- a/frontend/src/constants/screenBreakpoints.ts
+++ b/frontend/src/constants/screenBreakpoints.ts
@@ -1,5 +1,0 @@
-export const SCREEN_BREAKPOINT = {
-  sm: 375,
-  md: 1023,
-  lg: 1024,
-} as const;

--- a/frontend/src/constants/styles.ts
+++ b/frontend/src/constants/styles.ts
@@ -1,4 +1,11 @@
-import { SCREEN_BREAKPOINT } from './screenBreakpoints';
+// Web Responsive Constatns
+
+export const SCREEN_BREAKPOINT = {
+  sm: 375,
+  md: 1023,
+  lg: 1024,
+} as const;
+
 
 /**
  * css에서 반응형 디자인을 할 때 사용합니다.
@@ -20,10 +27,8 @@ import { SCREEN_BREAKPOINT } from './screenBreakpoints';
  *   }
  * `
  */
-const MEDIA_QUERY: Readonly<Record<keyof typeof SCREEN_BREAKPOINT, string>> = {
+export const MEDIA_QUERY: Readonly<Record<keyof typeof SCREEN_BREAKPOINT, string>> = {
   sm: `@media screen and (max-width: ${SCREEN_BREAKPOINT.sm}px)`,
   md: `@media screen and (max-width: ${SCREEN_BREAKPOINT.md}px)`,
   lg: `@media screen and (min-width: ${SCREEN_BREAKPOINT.lg}px)`,
 };
-
-export default MEDIA_QUERY;

--- a/frontend/src/hooks/useMediaQuery.ts
+++ b/frontend/src/hooks/useMediaQuery.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import { SCREEN_BREAKPOINT } from '../constants/screenBreakpoints';
+import { SCREEN_BREAKPOINT } from '../constants/styles';
 
 type ScreenKey = `is${Capitalize<keyof typeof SCREEN_BREAKPOINT>}`;
 type Screen = Map<ScreenKey, MediaQueryList>;

--- a/frontend/src/hooks/useMediaQuery.ts
+++ b/frontend/src/hooks/useMediaQuery.ts
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
-import SCREEN_BREAKPOINT, { ScreenBreakpoint } from '../constants/screenBreakpoints';
 
-type ScreenKey = `is${Capitalize<ScreenBreakpoint>}`;
+import { SCREEN_BREAKPOINT } from '../constants/screenBreakpoints';
+
+type ScreenKey = `is${Capitalize<keyof typeof SCREEN_BREAKPOINT>}`;
 type Screen = Map<ScreenKey, MediaQueryList>;
 
 /**

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -2,6 +2,7 @@ const HomePage = () => {
   return (
     <>
       <div>여기는 홈입니다.</div>
+      <div> 테스트 추가요! </div>
       <input type="file" accept="image/*"/>
     </>
   );

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -3,7 +3,7 @@ const HomePage = () => {
     <>
       <div>여기는 홈입니다.</div>
       <div> 테스트 추가요! </div>
-      <input type="file" accept="image/*"/>
+      <input type="file" accept="image/*" multiple/>
     </>
   );
 };


### PR DESCRIPTION
## 🔥 연관 이슈

close: #2 

## 📝 작업 요약

- 기존 Github Action CI/CD 환경에서 캐시로 인한 배포 문제 해결
- 반응형 관련 constants 내 type 선언 부분 수정

## 🔎 작업 상세 설명

- CloudFront 캐싱 전략으로 인한 부분 무효화 부분 추가
- 기존 유니온 타입으로 선언한 ```ScreenBreakpoint``` 영역을 지우고, ```keyof typeof```를 이용하여 유니온 타입 재선언

## 🌟 논의 사항

- 기존에 선언했던 유니온 타입에 대해서 지우고, 작업 상세 설명처럼 했는데 이 부분에 대해서 의견 부탁드려요!
- 그리고, ```mediaQuery```와 ```screenBreakpoints``` 영역을 ```styles```로 하나로 묶은 다음에 주석으로 구분해주는 건 어떻게 생각하시나요?
